### PR TITLE
Add setup-risor GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ Awesome [Risor](https://risor.io) related projects.
 
 ## Language related
 
-* [tree-sitter-risor](https://github.com/applejag/tree-sitter-risor) - Risor grammar for tree-sitter 
+* [tree-sitter-risor](https://github.com/applejag/tree-sitter-risor) - Risor grammar for tree-sitter
+
+## Continuous integration
+
+* [setup-risor](https://github.com/applejag/setup-risor) - Install Risor inside a GitHub Action workflow
 
 ## Additional modules/libraries
 


### PR DESCRIPTION
A GitHub Action for running Risor in GitHub Actions.

The change on the `tree-sitter-risor` line was just removal of a trailing space at the end of the line.